### PR TITLE
List todos by owners and body

### DIFF
--- a/client/cypress/integration/todos-list.spec.ts
+++ b/client/cypress/integration/todos-list.spec.ts
@@ -12,6 +12,21 @@ describe('Todos list', () => {
     page.getTodosTitle().should('have.text', 'Todos');
   });
 
+  it('Should type something in the owner filter and check that it returned correct elements', () => {
+    // Filter for todos 'Lynn Ferguson'
+    cy.get('#todos-owner-input').type('Lynn Ferguson');
+
+    // All of the todos cards should have the owner we are filtering by
+    page.getTodosCards().each(e => {
+      cy.wrap(e).find('.todos-card-owner').should('have.text', 'Lynn Ferguson');
+    });
+
+    // (We check this two ways to show multiple ways to check this)
+    page.getTodosCards().find('.todos-card-owner').each($el =>
+      expect($el.text()).to.equal('Lynn Ferguson')
+    );
+  });
+
 
   it('Should change the view', () => {
     // Choose the view type "List"

--- a/client/cypress/integration/todos-list.spec.ts
+++ b/client/cypress/integration/todos-list.spec.ts
@@ -29,17 +29,18 @@ describe('Todos list', () => {
 
   it('Should type something in the body filter and check that it returned correct elements', () => {
     // Filter for body 'in sunt'
-    cy.get('#todos-body-input').type('In sunt');
+    cy.get('#todos-body-input').type('In sunt ex non tempor cillum commodo amet incididunt anim qui commodo quis. Cillum non labore ex sint esse.');
 
     // All of the todos cards should have the body we are filtering by
     page.getTodosCards().find('.todos-card-body').each($card => {
-      cy.wrap($card).should('have.text', 'In sunt');
+      cy.wrap($card).should('have.text', 'In sunt ex non tempor cillum commodo amet incididunt ' +
+      'anim qui commodo quis. Cillum non labore ex sint esse.');
     });
   });
 
   it('Should type something partial in the body filter and check that it returned correct elements', () => {
     // Filter for bodies that contain 'ti'
-    cy.get('#todos-body-input').type('to');
+    cy.get('#todos-body-input').type('In sunt');
 
     // Go through each of the cards that are being shown and get the bodies
     page.getTodosCards().find('.todos-card-body')

--- a/client/cypress/integration/todos-list.spec.ts
+++ b/client/cypress/integration/todos-list.spec.ts
@@ -29,7 +29,8 @@ describe('Todos list', () => {
 
   it('Should type something in the body filter and check that it returned correct elements', () => {
     // Filter for body 'in sunt'
-    cy.get('#todos-body-input').type('In sunt ex non tempor cillum commodo amet incididunt anim qui commodo quis. Cillum non labore ex sint esse.');
+    cy.get('#todos-body-input').type('In sunt ex non tempor cillum commodo amet incididunt' +
+    ' anim qui commodo quis. Cillum non labore ex sint esse.');
 
     // All of the todos cards should have the body we are filtering by
     page.getTodosCards().find('.todos-card-body').each($card => {

--- a/client/cypress/integration/todos-list.spec.ts
+++ b/client/cypress/integration/todos-list.spec.ts
@@ -27,6 +27,30 @@ describe('Todos list', () => {
     );
   });
 
+  it('Should type something in the body filter and check that it returned correct elements', () => {
+    // Filter for body 'in sunt'
+    cy.get('#todos-body-input').type('In sunt');
+
+    // All of the todos cards should have the body we are filtering by
+    page.getTodosCards().find('.todos-card-body').each($card => {
+      cy.wrap($card).should('have.text', 'In sunt');
+    });
+  });
+
+  it('Should type something partial in the body filter and check that it returned correct elements', () => {
+    // Filter for bodies that contain 'ti'
+    cy.get('#todos-body-input').type('to');
+
+    // Go through each of the cards that are being shown and get the bodies
+    page.getTodosCards().find('.todos-card-body')
+      // We should see these bodies
+      .should('contain.text', 'Cillum non labore ex sint esse.')
+      .should('contain.text', 'Ipsum irure anim excepteur')
+      // We shouldn't see these bodies
+      .should('not.contain.text', 'im a horse')
+      .should('not.contain.text', 'grandma loves you');
+  });
+
 
   it('Should change the view', () => {
     // Choose the view type "List"

--- a/client/cypress/integration/todos-list.spec.ts
+++ b/client/cypress/integration/todos-list.spec.ts
@@ -13,17 +13,17 @@ describe('Todos list', () => {
   });
 
   it('Should type something in the owner filter and check that it returned correct elements', () => {
-    // Filter for todos 'Lynn Ferguson'
-    cy.get('#todos-owner-input').type('Lynn Ferguson');
+    // Filter for todos 'Fry'
+    cy.get('#todos-owner-input').type('Fry');
 
     // All of the todos cards should have the owner we are filtering by
     page.getTodosCards().each(e => {
-      cy.wrap(e).find('.todos-card-owner').should('have.text', 'Lynn Ferguson');
+      cy.wrap(e).find('.todos-card-owner').should('have.text', 'Fry');
     });
 
     // (We check this two ways to show multiple ways to check this)
     page.getTodosCards().find('.todos-card-owner').each($el =>
-      expect($el.text()).to.equal('Lynn Ferguson')
+      expect($el.text()).to.equal('Fry')
     );
   });
 

--- a/client/src/app/todos/todos-card.component.html
+++ b/client/src/app/todos/todos-card.component.html
@@ -3,7 +3,7 @@
     <mat-card-title class="todos-card-owner">{{ this.todos.owner }}</mat-card-title>
     <mat-card-subtitle class="todos-card-category">{{ this.todos.category }}</mat-card-subtitle>
   </mat-card-header>
-  <mat-card-content *ngIf="!this.simple">
+  <mat-card-content *ngIf="this.simple">
     <p>Status: <span class="todos-card-status">{{ todos.status }}</span></p>
     <p>Body: <span class="todos-card-body">{{ todos.body }}</span></p>
   </mat-card-content>

--- a/client/src/app/todos/todos-list.component.html
+++ b/client/src/app/todos/todos-list.component.html
@@ -5,6 +5,17 @@
       <mat-card-title class="todos-list-title">Todos</mat-card-title>
       <mat-card-content fxLayout="column" >
 
+        <div fxLayout="row wrap" fxLayoutGap="10px">
+          <!-- Examples of filtering in Angular -->
+
+          <mat-form-field class="input-field">
+            <mat-label>Owner</mat-label>
+            <input matInput id="todos-owner-input" placeholder="Filter by owner"
+            [(ngModel)]="todosOwner" (input)="updateFilter()">
+            <mat-hint>Filtered on client</mat-hint>
+          </mat-form-field>
+        </div>
+
         <br>
         <div fxLayout="row wrap" fxLayoutGap="10px">
           <label>View type: </label>

--- a/client/src/app/todos/todos-list.component.html
+++ b/client/src/app/todos/todos-list.component.html
@@ -14,6 +14,14 @@
             [(ngModel)]="todosOwner" (input)="updateFilter()">
             <mat-hint>Filtered on client</mat-hint>
           </mat-form-field>
+
+          <mat-form-field class="input-field">
+            <mat-label>Body</mat-label>
+            <input matInput id="todos-body-input" placeholder="Filter by body"
+            [(ngModel)]="todosBody" (input)="updateFilter()">
+            <mat-hint>Filtered on client</mat-hint>
+          </mat-form-field>
+
         </div>
 
         <br>

--- a/client/src/app/todos/todos-list.component.spec.ts
+++ b/client/src/app/todos/todos-list.component.spec.ts
@@ -92,7 +92,7 @@ describe('TodosListComponent', () => {
  * This test is a little odd, but illustrates how we can use "stubbing"
  * to create mock objects (a service in this case) that be used for
  * testing. Here we set up the mock TodosService (todosServiceStub) so that
- * _always_ fails (throws an exception) when you request a set of todoss.
+ * _always_ fails (throws an exception) when you request a set of todos.
  *
  * So this doesn't really test anything meaningful in the context of our
  * code (I certainly wouldn't copy it), but it does illustrate some nice

--- a/client/src/app/todos/todos-list.component.ts
+++ b/client/src/app/todos/todos-list.component.ts
@@ -16,6 +16,7 @@ export class TodosListComponent implements OnInit {
   public filteredTodos: Todos[];
 
   public todosOwner: string;
+  public todosBody: string;
   public viewType: 'card' | 'list' = 'card';
 
   // Inject the TodoService into this component.
@@ -29,7 +30,8 @@ export class TodosListComponent implements OnInit {
 
   getTodosFromServer() {
     this.todosService.getTodos({
-      owner: this.todosOwner
+      owner: this.todosOwner,
+      body: this.todosBody
     }).subscribe(returnedTodos => {
       this.serverFilteredTodos = returnedTodos;
       this.updateFilter();
@@ -55,7 +57,7 @@ export class TodosListComponent implements OnInit {
   }
   public updateFilter() {
     this.filteredTodos = this.todosService.filterTodos(
-      this.serverFilteredTodos, { owner: this.todosOwner });
+      this.serverFilteredTodos, { owner: this.todosOwner, body: this.todosBody });
   }
 
   /**

--- a/client/src/app/todos/todos.service.spec.ts
+++ b/client/src/app/todos/todos.service.spec.ts
@@ -77,6 +77,26 @@ describe('TodosService', () => {
       // actually being performed.
       req.flush(testTodos);
     });
+    describe('Calling getTodos() with parameters correctly forms the HTTP request', () => {
+
+      it('correctly calls api/todos with filter parameter \'pam\'', () => {
+        todosService.getTodos({ owner: 'pam' }).subscribe(
+          todos => expect(todos).toBe(testTodos)
+        );
+
+        // Specify that (exactly) one request will be made to the specified URL with the owner parameter.
+        const req = httpTestingController.expectOne(
+          (request) => request.url.startsWith(todosService.todosUrl) && request.params.has('owner')
+        );
+
+        // Check that the request made to that URL was a GET request.
+        expect(req.request.method).toEqual('GET');
+
+        // Check that the owner parameter was 'pam'
+        expect(req.request.params.get('owner')).toEqual('pam');
+
+        req.flush(testTodos);
+      });
   });
 
   describe('getTodosByID()', () => {
@@ -126,4 +146,5 @@ describe('TodosService', () => {
       });
     });
   });
+ });
 });

--- a/client/src/app/todos/todos.service.spec.ts
+++ b/client/src/app/todos/todos.service.spec.ts
@@ -103,9 +103,9 @@ describe('TodosService', () => {
           todos => expect(todos).toBe(testTodos)
         );
 
-        // Specify that (exactly) one request will be made to the specified URL with the owner parameter.
+        // Specify that (exactly) one request will be made to the specified URL with the body parameter.
         const req = httpTestingController.expectOne(
-          (request) => request.url.startsWith(todosService.todosUrl) && request.params.has('owner')
+          (request) => request.url.startsWith(todosService.todosUrl) && request.params.has('body')
         );
 
         // Check that the request made to that URL was a GET request.
@@ -166,7 +166,7 @@ describe('TodosService', () => {
     });
 
     it('filters by body', () => {
-      const todosBody = 'happyss';
+      const todosBody = 'happy';
       const filteredTodos = todosService.filterTodos(testTodos, { body: todosBody });
       // There should be just one todos that has UMM as their body.
       expect(filteredTodos.length).toBe(1);

--- a/client/src/app/todos/todos.service.spec.ts
+++ b/client/src/app/todos/todos.service.spec.ts
@@ -97,6 +97,25 @@ describe('TodosService', () => {
 
         req.flush(testTodos);
       });
+
+      it('correctly calls api/todos with filter parameter \'pull\'', () => {
+        todosService.getTodos({ body: 'pull' }).subscribe(
+          todos => expect(todos).toBe(testTodos)
+        );
+
+        // Specify that (exactly) one request will be made to the specified URL with the owner parameter.
+        const req = httpTestingController.expectOne(
+          (request) => request.url.startsWith(todosService.todosUrl) && request.params.has('owner')
+        );
+
+        // Check that the request made to that URL was a GET request.
+        expect(req.request.method).toEqual('GET');
+
+        // Check that the body parameter was 'pull'
+        expect(req.request.params.get('body')).toEqual('pull');
+
+        req.flush(testTodos);
+      });
   });
 
   describe('getTodosByID()', () => {
@@ -143,6 +162,17 @@ describe('TodosService', () => {
       // Every returned todos owner should contain an 'i'.
       filteredTodos.forEach(todos => {
         expect(todos.owner.indexOf(todosName)).toBeGreaterThanOrEqual(0);
+      });
+    });
+
+    it('filters by body', () => {
+      const todosBody = 'happyss';
+      const filteredTodos = todosService.filterTodos(testTodos, { body: todosBody });
+      // There should be just one todos that has UMM as their body.
+      expect(filteredTodos.length).toBe(1);
+      // Every returned todo's body should contain 'UMM'.
+      filteredTodos.forEach(todos => {
+        expect(todos.body.indexOf(todosBody)).toBeGreaterThanOrEqual(0);
       });
     });
   });

--- a/client/src/app/todos/todos.service.ts
+++ b/client/src/app/todos/todos.service.ts
@@ -22,6 +22,9 @@ export class TodosService {
       if (filters.owner) {
         httpParams = httpParams.set('owner', filters.owner);
       }
+      if (filters.body) {
+        httpParams = httpParams.set('body', filters.body);
+      }
     }
     return this.httpClient.get<Todos[]>(this.todosUrl, {
       params: httpParams,
@@ -41,6 +44,12 @@ export class TodosService {
       filters.owner = filters.owner.toLowerCase();
 
       filteredTodos = filteredTodos.filter(todo => todo.owner.toLowerCase().indexOf(filters.owner) !== -1);
+    }
+    // Filter by body
+    if (filters.body) {
+      filters.body = filters.body.toLowerCase();
+
+      filteredTodos = filteredTodos.filter(todo => todo.body.toLowerCase().indexOf(filters.body) !== -1);
     }
 
     return filteredTodos;

--- a/client/src/app/todos/todos.service.ts
+++ b/client/src/app/todos/todos.service.ts
@@ -16,7 +16,7 @@ export class TodosService {
 
 
 
-  getTodos(filters?: { owner?: string }): Observable<Todos[]> {
+  getTodos(filters?: { body?: string; owner?: string }): Observable<Todos[]> {
     let httpParams: HttpParams = new HttpParams();
     if (filters) {
       if (filters.owner) {
@@ -32,7 +32,7 @@ export class TodosService {
     return this.httpClient.get<Todos>(this.todosUrl + '/' + id);
   }
 
-  filterTodos(todos: Todos[], filters: { owner?: string }): Todos[] {
+  filterTodos(todos: Todos[], filters: { body?: string; owner?: string }): Todos[] {
 
     let filteredTodos = todos;
 

--- a/client/src/testing/todos.service.mock.ts
+++ b/client/src/testing/todos.service.mock.ts
@@ -37,7 +37,7 @@ export class MockTodosService extends TodosService {
     super(null);
   }
 
-  getTodos(filters: { owner?: string }): Observable<Todos[]> {
+  getTodos(filters: { body?: string; owner?: string }): Observable<Todos[]> {
     // Our goal here isn't to test (and thus rewrite) the service, so we'll
     // keep it simple and just return the test users regardless of what
     // filters are passed in.


### PR DESCRIPTION
We've added the ability to filter todos by owner and by body here using the client to do all the work. 
Co-authored-by: Josh Quist quist127@morris.umn.edu.